### PR TITLE
Fix repeated warnings about deprecated use of object.actor in gnome-shell 3.34.

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -255,6 +255,9 @@ function init() {
 }
 
 function enable() {
+  if (MessageTray.Source.prototype.countUpdated == _countUpdated) {
+    return;
+  }
   originalCountUpdated = MessageTray.Source.prototype.countUpdated;
   originalDestroy = MessageTray.Source.prototype.destroy;
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -22,6 +22,7 @@
  *
  */
 
+const { Clutter, St } = imports.gi;
 const Lang = imports.lang;
 const Mainloop = imports.mainloop;
 const Main = imports.ui.main;
@@ -163,13 +164,12 @@ function _MessageStyleHandler() {
     }
 
     let dateMenu = Main.panel.statusArea.dateMenu;
-    let actualStyle = (dateMenu.actor.style) ? dateMenu.actor.style : "";
+    let actor = dateMenu instanceof Clutter.Actor ? dateMenu : dateMenu.actor;
+    let actualStyle = (actor.style) ? actor.style : "";
 
     let userStyle = "color: " + settings.get_string(SETTING_COLOR) + ";";
 
-    dateMenu.actor.style = (dateMenu.actor.style == this._oldStyle) ?
-      actualStyle.concat(userStyle) : this._oldStyle;
-
+    actor.style = (actor.style == this._oldStyle) ?  actualStyle.concat(userStyle) : this._oldStyle;
 
     // keep looping
     return true;
@@ -183,7 +183,8 @@ function _MessageStyleHandler() {
     let dateMenu = Main.panel.statusArea.dateMenu;
     let loopDelay = settings.get_int(SETTING_BLINK_RATE);
 
-    this._oldStyle = dateMenu.actor.style;
+    let actor = dateMenu instanceof Clutter.Actor ? dateMenu : dateMenu.actor;
+    this._oldStyle = actor.style;
     this._hasStyleAdded = true;
 
     if (loopDelay > 0) {
@@ -207,7 +208,8 @@ function _MessageStyleHandler() {
     }
 
     let dateMenu = Main.panel.statusArea.dateMenu;
-    dateMenu.actor.style = this._oldStyle;
+    let actor = dateMenu instanceof Clutter.Actor ? dateMenu : dateMenu.actor;
+    actor.style = this._oldStyle;
     this._oldStyle = null;
   }
 


### PR DESCRIPTION
I'm just going to cut and paste from the first commit, the second commit is a bug fix for an issue that's annoying while debugging, but otherwise impossible to hit.

In gnome-shell 3.34, the use of Main.panel.statusArea.dateMenu.actor is
deprecated.

That is because Main.panel.statusArea.dateMenu is actually an actor, and
so Main.panel.statusArea.dateMenu.actor will be going away with the next
release.

That in turn means that right now this extension is spamming the
following for every single blink action:

gnome-shell[14970]: Usage of object.actor is deprecated for DateMenuButton
                    get@resource:///org/gnome/shell/ui/environment.js:242:29
                    _MessageStyleHandler/this._toggleStyle@/home/x/.local/share/gnome-shell/extensions/notifications-alert-on-user-menu@hackedbellini.gmail.com/extension.js:166:9

This is fairly suboptimal.

The correct fix is to check to see if Main.panel.statusArea.dateMenu is
a Clutter.Actor, and if so, just use it directly, and if not, use
Main.panel.statusArea.dateMenu.actor as before.

This has been tested on gnome-shell 3.34.1 on Ubuntu 19.10.