### PR TITLE
Add support for background color changes.

### DIFF
--- a/schemas/org.gnome.shell.extensions.notifications-alert.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.notifications-alert.gschema.xml
@@ -16,10 +16,25 @@
       <summary>Blink rate</summary>
       <description>The rate that the alert blinks, in ms. 0 means no blink</description>
     </key>
+    <key name="usecolor" type="b">
+      <default>true</default>
+      <summary>Use alert color</summary>
+      <description>Use the alert color for alert blinks</description>
+    </key>
     <key name="color" type="s">
       <default>'#ff0000'</default>
       <summary>Alert color</summary>
       <description>The color used to paint the message on user's menu</description>
+    </key>
+    <key name="usebackgroundcolor" type="b">
+      <default>false</default>
+      <summary>Use alert background color</summary>
+      <description>Use the alert background color for alert blinks</description>
+    </key>
+    <key name="backgroundcolor" type="s">
+      <default>'#ff0000'</default>
+      <summary>Alert background color</summary>
+      <description>The background color used to paint the message on user's menu</description>
     </key>
     <key name="application-list" type="as">
       <default>[ ]</default>

--- a/src/extension.js
+++ b/src/extension.js
@@ -34,7 +34,10 @@ const Me = ExtensionUtils.getCurrentExtension();
 const Lib = Me.imports.lib;
 
 const SETTING_BLINK_RATE = 'blinkrate';
+const SETTING_USECOLOR = 'usecolor';
 const SETTING_COLOR = 'color';
+const SETTING_USEBACKGROUNDCOLOR = 'usebackgroundcolor';
+const SETTING_BACKGROUNDCOLOR = 'backgroundcolor';
 const SETTING_CHAT_ONLY = 'chatonly';
 const SETTING_FORCE = 'force';
 const SETTING_BLACKLIST = 'application-list';
@@ -74,7 +77,10 @@ function _MessageStyleHandler() {
 
     // Connect settings change events, so we can update message style
     // as soon as the user makes the change
+    this._connectSetting(SETTING_USECOLOR);
     this._connectSetting(SETTING_COLOR);
+    this._connectSetting(SETTING_BACKGROUNDCOLOR);
+    this._connectSetting(SETTING_USEBACKGROUNDCOLOR);
     this._connectSetting(SETTING_CHAT_ONLY);
     this._connectSetting(SETTING_FORCE);
     this._connectSetting(SETTING_BLINK_RATE);
@@ -167,7 +173,13 @@ function _MessageStyleHandler() {
     let actor = dateMenu instanceof Clutter.Actor ? dateMenu : dateMenu.actor;
     let actualStyle = (actor.style) ? actor.style : "";
 
-    let userStyle = "color: " + settings.get_string(SETTING_COLOR) + ";";
+    let userStyle = "";
+    if (settings.get_boolean(SETTING_USECOLOR)) {
+	userStyle += "color: " + settings.get_string(SETTING_COLOR) + ";";
+    }
+    if (settings.get_boolean(SETTING_USEBACKGROUNDCOLOR)) {
+	userStyle += "background-color: " + settings.get_string(SETTING_BACKGROUNDCOLOR) + ";";
+    }
 
     actor.style = (actor.style == this._oldStyle) ?  actualStyle.concat(userStyle) : this._oldStyle;
 

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -173,6 +173,10 @@ function init() {
       label: _("Alert color"),
       help: _("The color used to paint the message on user's menu")
     },
+    backgroundcolor: {
+      label: _("Alert background color"),
+      help: _("The background color used to paint the message on user's menu")
+    },
   };
 
   intSettings = {
@@ -186,6 +190,14 @@ function init() {
   };
 
   boolSettings = {
+    usecolor: {
+      label: _("Use alert color"),
+      help: _("Use the alert color for alert blinks (default: ON)")
+    },
+    usebackgroundcolor: {
+      label: _("Use alert background color"),
+      help: _("Use the alert background color for alert blinks (default: OFF)")
+    },
     chatonly: {
       label: _("Only alert for chat notifications"),
       help: _("Only chat notifications (like Empathy ones) will get alerted (default: OFF)")


### PR DESCRIPTION
This implements the 'simple background blinking' mode suggested in
issue #36.
(https://github.com/bellini666/gnome-shell-notifications-alert/issues/36)

To do this, we have added 3 new settings:

'Use alert color' toggles if we want to actually use the defined color
for alerts, this defaults true.  If false, the color of the text remains
as the theme default.

'Use alert background color' does the exact same thing, but for the
background color.  This defaults false.

And 'Alert background color' defines the background color that we want
to use, assuming that 'Use alert background color' is true.

The implementation is fairly straight forward, if SETTING_USECOLOR is
true, add the style CSS for the color setting.  If
SETTING_USEBACKGROUNDCOLOR is true, add the style CSS for the
background-color setting.

If both are false, then we go through a lot of fuss and bother to set a
blank style.