### PR TITLE
Gnome 40

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 UUID=notifications-alert-on-user-menu@hackedbellini.gmail.com
 INSTALL_PATH=~/.local/share/gnome-shell/extensions/$(UUID)
+UPDATE_PATH=~/.local/share/gnome-shell/extension-updates/$(UUID)
 ZIP_PATH=$(UUID).zip
 SRC_PATH=src
 SCHEMAS_PATH=schemas
@@ -26,6 +27,10 @@ zip-file: locale
 install: zip-file
 	mkdir -p $(INSTALL_PATH) && \
 	unzip -o $(ZIP_PATH) -d $(INSTALL_PATH)
+
+update: zip-file
+	mkdir -p $(UPDATE_PATH) && \
+	unzip -o $(ZIP_PATH) -d $(UPDATE_PATH)
 
 uninstall:
 	rm $(INSTALL_PATH) -rf

--- a/src/lib.js
+++ b/src/lib.js
@@ -79,43 +79,15 @@ function getSettings(extension) {
    Color utils
  */
 
-function _scaleRound(value) {
-  // Based on gtk/gtkcoloreditor.c
-  value = Math.floor((value / 255) + 0.5);
-  value = Math.max(value, 0);
-  value = Math.min(value, 255);
-  return value;
-}
+function getRGBAColor(rgba) {
+  let color = new Gdk.RGBA();
 
-function _dec2Hex(value) {
-  value = value.toString(16);
-
-  while (value.length < 2) {
-    value = '0' + value;
-  }
-
-  return value;
-}
-
-function getColorByHexadecimal(hex) {
-  let colorArray = Gdk.Color.parse(hex);
-  let color = null;
-
-  if (colorArray[0]) {
-    color = colorArray[1];
-  } else {
+  if (!color.parse(rgba)) {
     // On any error, default to red
-    color = new Gdk.Color({red: 65535});
+    color = new Gdk.RGBA({red: 1.0, alpha: 1.0});
   }
 
   return color;
-}
-
-function getHexadecimalByColor(color) {
-  let red = _scaleRound(color.red);
-  let green = _scaleRound(color.green);
-  let blue = _scaleRound(color.blue);
-  return "#" + _dec2Hex(red) + _dec2Hex(green) + _dec2Hex(blue);
 }
 
 function getAppNamesFromAppInfos(list) {

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -1,7 +1,10 @@
 {
   "shell-version": [
     "40",
-    "41"
+    "41",
+    "42",
+    "43",
+    "44"
   ],
   "uuid": "notifications-alert-on-user-menu@hackedbellini.gmail.com",
   "name": "Notifications Alert",

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -1,15 +1,7 @@
 {
   "shell-version": [
-    "3.16",
-    "3.18",
-    "3.20",
-    "3.22",
-    "3.24",
-    "3.26",
-    "3.28",
-    "3.30",
-    "3.32",
-    "3.34"
+    "40",
+    "41"
   ],
   "uuid": "notifications-alert-on-user-menu@hackedbellini.gmail.com",
   "name": "Notifications Alert",

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -23,7 +23,6 @@
 const GObject = imports.gi.GObject;
 const Gio = imports.gi.Gio;
 const Gtk = imports.gi.Gtk;
-const Lang = imports.lang;
 
 const Gettext = imports.gettext.domain('gnome-shell-notifications-alert');
 const _ = Gettext.gettext;
@@ -50,7 +49,7 @@ function _createBoolSetting(setting) {
   let hbox = new Gtk.Box({orientation: Gtk.Orientation.HORIZONTAL});
 
   let settingLabel = new Gtk.Label({label: boolSettings[setting].label,
-                                    xalign: 0});
+                                    xalign: 0, hexpand: true});
 
   let settingSwitch = new Gtk.Switch({active: settings.get_boolean(setting)});
   settingSwitch.connect('notify::active', function(button) {
@@ -62,8 +61,8 @@ function _createBoolSetting(setting) {
     settingSwitch.set_tooltip_text(boolSettings[setting].help);
   }
 
-  hbox.pack_start(settingLabel, true, true, 0);
-  hbox.add(settingSwitch);
+  hbox.prepend(settingLabel);
+  hbox.append(settingSwitch);
 
   return hbox;
 }
@@ -72,7 +71,7 @@ function _createIntSetting(setting) {
   let hbox = new Gtk.Box({orientation: Gtk.Orientation.HORIZONTAL});
 
   let settingLabel = new Gtk.Label({label: intSettings[setting].label,
-                                    xalign: 0});
+                                    xalign: 0, hexpand: true});
 
   let spinButton = Gtk.SpinButton.new_with_range(
     intSettings[setting].min,
@@ -88,8 +87,8 @@ function _createIntSetting(setting) {
     spinButton.set_tooltip_text(intSettings[setting].help);
   }
 
-  hbox.pack_start(settingLabel, true, true, 0);
-  hbox.add(spinButton);
+  hbox.prepend(settingLabel);
+  hbox.append(spinButton);
 
   return hbox;
 }
@@ -98,14 +97,14 @@ function _createColorSetting(setting) {
   let hbox = new Gtk.Box({orientation: Gtk.Orientation.HORIZONTAL});
 
   let settingLabel = new Gtk.Label({label: colorSettings[setting].label,
-                                    xalign: 0});
+                                    xalign: 0, hexpand: true});
 
-  let color = Lib.getColorByHexadecimal(settings.get_string(setting));
+  let color = Lib.getRGBAColor(settings.get_string(setting));
   let colorButton = new Gtk.ColorButton();
-  colorButton.set_color(color);
-  colorButton.connect('notify::color', function(button) {
-    let hex = Lib.getHexadecimalByColor(button.get_color());
-    settings.set_string(setting, hex);
+  colorButton.set_rgba(color);
+  colorButton.connect('notify::rgba', function(button) {
+    let rgba = button.get_rgba().to_string();
+    settings.set_string(setting, rgba);
   });
 
   if (colorSettings[setting].help) {
@@ -113,8 +112,8 @@ function _createColorSetting(setting) {
     colorButton.set_tooltip_text(colorSettings[setting].help);
   }
 
-  hbox.pack_start(settingLabel, true, true, 0);
-  hbox.add(colorButton);
+  hbox.prepend(settingLabel);
+  hbox.append(colorButton);
 
   return hbox;
 }
@@ -122,7 +121,7 @@ function _createColorSetting(setting) {
 function _createFilterListSetting() {
   let settingLabel = new Gtk.Label({label: _("Filter List"), xalign: 0});
   let widget = new Widget();
-  let blbox = new Gtk.Grid({column_spacing: 5, row_spacing: 5, margin: 0});
+  let blbox = new Gtk.Grid({column_spacing: 5, row_spacing: 5});
   blbox.attach(settingLabel,0,0,1,1);
   blbox.attach(widget,0,1,1,1);
   return blbox;
@@ -130,15 +129,15 @@ function _createFilterListSetting() {
 
 function _createFilterTypeSetting() {
   let hbox = new Gtk.Box({orientation: Gtk.Orientation.HORIZONTAL});
-  let settingLabel = new Gtk.Label({label: _("Filter Type"), xalign: 0});
+  let settingLabel = new Gtk.Label({label: _("Filter Type"), xalign: 0, hexpand: true});
 
   let listStore = new Gtk.ListStore();
   listStore.set_column_types ([
     GObject.TYPE_STRING,
     GObject.TYPE_STRING]);
 
-  listStore.insert_with_valuesv (-1,  [0, 1], [0, _("Blacklist")]);
-  listStore.insert_with_valuesv (-1,  [0, 1], [1, _("Whitelist")]);
+  listStore.insert_with_values (-1,  [0, 1], [0, _("Blacklist")]); //valuesv
+  listStore.insert_with_values (-1,  [0, 1], [1, _("Whitelist")]); //valuesv
 
   let filterComboBox = new Gtk.ComboBox({ model: listStore });
   filterComboBox.set_active (settings.get_int(SETTING_FILTER_TYPE));
@@ -155,8 +154,8 @@ function _createFilterTypeSetting() {
     settings.set_int(SETTING_FILTER_TYPE, id);
   });
 
-  hbox.pack_start(settingLabel, true, true, 0);
-  hbox.add(filterComboBox);
+  hbox.prepend(settingLabel);
+  hbox.append(filterComboBox);
   return hbox;
 }
 
@@ -216,7 +215,7 @@ function init() {
 const Widget = new GObject.Class({
   Name: 'NotificationsAlert.Prefs.BlackListWidget',
   GTypeName: 'NotificationsAlertBlackListPrefsWidget',
-  Extends: Gtk.Grid,
+  Extends: Gtk.Box,
 
   _init: function(params) {
     this.parent(params);
@@ -228,10 +227,10 @@ const Widget = new GObject.Class({
     this._store = new Gtk.ListStore();
     this._store.set_column_types([Gio.AppInfo, GObject.TYPE_STRING, Gio.Icon]);
 
-    let scrolled = new Gtk.ScrolledWindow({ shadow_type: Gtk.ShadowType.IN});
+    let scrolled = new Gtk.ScrolledWindow();
     scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC);
     scrolled.set_min_content_height(150);
-    this.add(scrolled);
+    this.append(scrolled);
 
     this._treeView = new Gtk.TreeView({ model: this._store,
                                         hexpand: true, vexpand: true });
@@ -247,21 +246,20 @@ const Widget = new GObject.Class({
     appColumn.add_attribute(nameRenderer, "text", Columns.DISPLAY_NAME);
     this._treeView.append_column(appColumn);
 
-    scrolled.add(this._treeView);
+    scrolled.set_child(this._treeView);
 
-    let toolbar = new Gtk.Toolbar({ icon_size: Gtk.IconSize.SMALL_TOOLBAR });
-    toolbar.get_style_context().add_class(Gtk.STYLE_CLASS_INLINE_TOOLBAR);
-    this.add(toolbar);
+    let toolbar = new Gtk.Box();
+    toolbar.get_style_context().add_class("toolbar");
+    this.append(toolbar);
 
-    let newButton = new Gtk.ToolButton({ icon_name: 'bookmark-new-symbolic',
-                                         label: _("Add Rule"),
-                                         is_important: true });
-    newButton.connect('clicked', Lang.bind(this, this._createNew));
-    toolbar.add(newButton);
+    let newButton = new Gtk.Button({ icon_name: 'bookmark-new-symbolic',
+                                     label: _("Add Rule") });
+    newButton.connect('clicked', this._createNew.bind(this));
+    toolbar.append(newButton);
 
-    let delButton = new Gtk.ToolButton({ icon_name: 'edit-delete-symbolic'  });
-      delButton.connect('clicked', Lang.bind(this, this._deleteSelected));
-      toolbar.add(delButton);
+    let delButton = new Gtk.Button({ icon_name: 'edit-delete-symbolic' });
+      delButton.connect('clicked', this._deleteSelected.bind(this));
+      toolbar.append(delButton);
 
     this._changedPermitted = true;
     this._refresh();
@@ -269,24 +267,24 @@ const Widget = new GObject.Class({
 
   _createNew: function() {
     let dialog = new Gtk.Dialog({ title: _("Blacklist app"),
-                                  transient_for: this.get_toplevel(),
+                                  transient_for: this.get_root(),
                                   use_header_bar: true,
                                   modal: true });
-    dialog.add_button(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL);
+    dialog.add_button("_Cancel", Gtk.ResponseType.CANCEL);
     let addButton = dialog.add_button(_("Add"), Gtk.ResponseType.OK);
     dialog.set_default_response(Gtk.ResponseType.OK);
 
     dialog._appChooser = new Gtk.AppChooserWidget({ show_all: true });
 
     let lbl = new Gtk.Label({label: _("Choose an application to blacklist:"),
-                             xalign: 0.5});
-    let hbox = new Gtk.Box({orientation: Gtk.Orientation.VERTICAL,
-                            margin: 5});
-    hbox.pack_start(lbl, false, true, 0);
-    hbox.pack_start(dialog._appChooser, true, true, 0);
-    dialog.get_content_area().pack_start(hbox, true, true, 0);
+                             xalign: 0.5, margin_bottom: 5});
+    let hbox = new Gtk.Box({orientation: Gtk.Orientation.VERTICAL, hexpand: true,
+                            margin_top: 10, margin_bottom: 10, margin_start: 10, margin_end: 10});
+    hbox.append(lbl);
+    hbox.append(dialog._appChooser);
+    dialog.get_content_area().append(hbox);
 
-    dialog.connect('response', Lang.bind(this, function(dialog, id) {
+    dialog.connect('response', function(dialog, id) {
       if (id != Gtk.ResponseType.OK) {
         dialog.destroy();
         return;
@@ -311,9 +309,9 @@ const Widget = new GObject.Class({
         [appInfo, appInfo.get_icon(), appInfo.get_display_name()]);
 
       dialog.destroy();
-      }));
+      }.bind(this));
 
-    dialog.show_all();
+    dialog.show();
   },
 
   _deleteSelected: function() {
@@ -378,38 +376,36 @@ const Widget = new GObject.Class({
 });
 
 function buildPrefsWidget() {
-  let frame = new Gtk.Box({orientation: Gtk.Orientation.VERTICAL,
-                           border_width: 10});
-  let vbox = new Gtk.Box({orientation: Gtk.Orientation.VERTICAL,
-                          margin: 20, margin_top: 10, spacing: 5});
+  let frame = new Gtk.Box({orientation: Gtk.Orientation.VERTICAL});
+  let vbox = new Gtk.Box({orientation: Gtk.Orientation.VERTICAL, spacing: 5,
+                          margin_top: 10, margin_bottom: 20, margin_start: 20, margin_end: 20});
   let setting;
 
   // Add all color settings
   for (setting in colorSettings) {
     let hbox = _createColorSetting(setting);
-    vbox.add(hbox);
+    vbox.append(hbox);
   }
   // Add all bool settings
   for (setting in boolSettings) {
     let hbox = _createBoolSetting(setting);
-    vbox.add(hbox);
+    vbox.append(hbox);
   }
   // Add all int settings
   for (setting in intSettings) {
     let hbox = _createIntSetting(setting);
-    vbox.add(hbox);
+    vbox.append(hbox);
   }
 
   // Add filter type setting
   let filterType = _createFilterTypeSetting();
-  vbox.add(filterType);
+  vbox.append(filterType);
 
   // Add filter list
   let blbox = _createFilterListSetting();
-  vbox.add(blbox);
+  vbox.append(blbox);
 
-  frame.add(vbox);
-  frame.show_all();
+  frame.append(vbox);
 
   return frame;
 }


### PR DESCRIPTION
Hi there,

I tried to port this extension to Gnome 40 (https://github.com/bellini666/gnome-shell-notifications-alert/issues/55).
My tests (Ubuntu 21.10) seemed to be fine, but since I'm new to Gnome extensions review is requested.
I couldn't replicate the look of the filter list toolbar in preferences, but it is working.
I also didn't test Gnome 41.
This likely breaks pre-40-compatibility, so I removed these versions.