### PR TITLE
Fixes for ego review

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ zip-file: locale
 	glib-compile-schemas $(SCHEMAS_PATH) \
 		--targetdir=$(SCHEMAS_PATH) \
 		--strict && \
-	zip -r -u $(ZIP_PATH) $(LOCALE_PATH) && \
+	zip -r -u $(ZIP_PATH) $(LOCALE_PATH) -x '*.po' '*.pot' && \
 	zip -r -u $(ZIP_PATH) $(SCHEMAS_PATH) && \
 	cd $(SRC_PATH) && \
 	zip -r -u ../$(ZIP_PATH) .

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,15 @@ SRC_PATH=src
 SCHEMAS_PATH=schemas
 LOCALE_DOMAIN=gnome-shell-notifications-alert
 LOCALE_PATH=locale
+LOCALES_TEMPLATE=${LOCALE_PATH}/messages.pot
 LOCALES=pt_BR de_DE cs_CZ nl_NL
+
+locale-files:
+	xgettext --from-code=UTF-8 --keyword=_ --sort-output --language=JavaScript src/*.js -o "${LOCALES_TEMPLATE}" && \
+	xgettext --join-existing --from-code=UTF-8 --keyword=translatable --sort-output --language=Glade src/*.ui -o "${LOCALES_TEMPLATE}" && \
+	for i in $(LOCALES); do \
+		msgmerge -U "$(LOCALE_PATH)/$$i.po" "${LOCALES_TEMPLATE}"; \
+	done
 
 locale:
 	for i in $(LOCALES); do \

--- a/locale/cs_CZ.po
+++ b/locale/cs_CZ.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-12-09 21:12-0300\n"
+"POT-Creation-Date: 2023-03-25 10:34+0100\n"
 "PO-Revision-Date: 2020-02-23 10:15+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,100 +18,101 @@ msgstr ""
 "X-Generator: Poedit 2.0.1\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
-#: src/prefs.js:276
+#: src/prefs.js:114
 msgid "Add"
 msgstr "Přidat"
 
-#: src/prefs.js:257
+#: src/prefs.js:96
 msgid "Add Rule"
 msgstr "Přidat pravidlo"
 
-#: src/prefs.js:177
+#: src/prefs.ui:55
 msgid "Alert background color"
 msgstr "Barva pozadí výstrahy"
 
-#: src/prefs.js:207
+#: src/prefs.ui:148 src/prefs.ui:159
 msgid "Alert even if you set notifications to OFF on user menu (default: OFF)"
 msgstr ""
-"Výstrahy i když je zobrazování upozorňování v uživatelské nabídce vypnuto"
-"(výchozí: vypnuto)"
+"Výstrahy i když je zobrazování upozorňování v uživatelské nabídce "
+"vypnuto (výchozí: vypnuto)"
 
-#: src/prefs.js:173
+#: src/prefs.ui:30
 msgid "Alert font color"
 msgstr "Barva písma výstrahy"
 
-#: src/prefs.js:241
+#: src/prefs.js:80
 msgid "Application"
 msgstr "Aplikace"
 
-#: src/prefs.js:140
+#: src/prefs.ui:214
 msgid "Blacklist"
 msgstr "Seznam vyloučených"
 
-#: src/prefs.js:271
+#: src/prefs.js:109
 msgid "Blacklist app"
 msgstr "Zařadit aplikaci na seznam vyloučených"
 
-#: src/prefs.js:184
+#: src/prefs.ui:176
 msgid "Blink rate (in ms)"
 msgstr "Rychlost blikání (v ms)"
 
-#: src/prefs.js:281
+#: src/prefs.js:119
 msgid "Choose an application to blacklist:"
 msgstr "Zvolte aplikaci pro zařazení na seznam vyloučených:"
 
-#: src/prefs.js:123
+#: src/prefs.js:44
 msgid "Filter List"
 msgstr "Seznam filtru"
 
-#: src/prefs.js:133
+#: src/prefs.ui:206
 msgid "Filter Type"
 msgstr "Typ filtru"
 
-#: src/prefs.js:206
+#: src/prefs.ui:152
 msgid "Force alerting even when notifications are set to OFF"
 msgstr "Zvýrazňovat i pokud jsou upozorňování vypnuta"
 
-#: src/prefs.js:202
+#: src/prefs.ui:128
 msgid "Only alert for chat notifications"
 msgstr "Zobrazovat výstrahy pouze na zprávy konverzací"
 
-#: src/prefs.js:203
+#: src/prefs.ui:124 src/prefs.ui:135
 msgid ""
 "Only chat notifications (like Empathy ones) will get alerted (default: OFF)"
 msgstr ""
-"Výstrahy budou zobrazovány pouze pro zprávy konverzací – např. Empathy (výchozí: vypnuto)"
+"Výstrahy budou zobrazovány pouze pro zprávy konverzací – např. Empathy "
+"(výchozí: vypnuto)"
 
-#: src/prefs.js:178
+#: src/prefs.ui:51 src/prefs.ui:63
 msgid "The background color used to paint the message on user's menu"
 msgstr "Barva pozadí, kterou je zobrazena zpráva v uživatelské nabídce"
 
-#: src/prefs.js:174
+#: src/prefs.ui:26 src/prefs.ui:38
 msgid "The color used to paint the message on user's menu"
 msgstr "Barva, kterou je zobrazena zpráva v uživatelské nabídce"
 
-#: src/prefs.js:185
+#: src/prefs.ui:172 src/prefs.ui:189
 msgid "The rate that the alert blinks, in ms. 0 means no blink (default: 800)"
 msgstr ""
 "Určuje, jakou rychlostí má problikávat zvýrazňující a výchozí barva "
 "(800=výchozí hodnota, méně=rychleji, více=pomaleji, 0=žádné blikání)"
 
-#: src/prefs.js:198
+#: src/prefs.ui:104
 msgid "Use alert background color"
 msgstr "Použít barvu pozadí výstrahy"
 
-#: src/prefs.js:194
+#: src/prefs.ui:80
 msgid "Use alert font color"
 msgstr "Použít barvu písma výstrahy"
 
-#: src/prefs.js:199
+#: src/prefs.ui:100 src/prefs.ui:111
 msgid "Use the alert background color for alert blinks (default: OFF)"
 msgstr "Blikat barvou jakou má pozadí výstrahy (výchozí: vypnuto)"
 
-#: src/prefs.js:195
+#: src/prefs.ui:76 src/prefs.ui:87
 msgid "Use the alert font color for alert blinks (default: ON)"
 msgstr "Blikat barvou jakou má písmo výstrahy (výchozí: zapnuto)"
 
-#: src/prefs.js:141
+#: src/prefs.ui:215
 msgid "Whitelist"
 msgstr "Seznam povolených"

--- a/locale/de_DE.po
+++ b/locale/de_DE.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-notifications-alert\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-12-09 21:12-0300\n"
+"POT-Creation-Date: 2023-03-25 10:34+0100\n"
 "PO-Revision-Date: 2019-12-29 21:14+0100\n"
 "Last-Translator: Onno Giesmann <nutzer3105@gmail.com>\n"
 "Language-Team: German <--->\n"
@@ -19,108 +19,108 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.2.4\n"
 
-#: src/prefs.js:276
+#: src/prefs.js:114
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: src/prefs.js:257
+#: src/prefs.js:96
 msgid "Add Rule"
 msgstr "Regel hinzufügen"
 
-#: src/prefs.js:177
+#: src/prefs.ui:55
 msgid "Alert background color"
 msgstr "Hintergrundfarbe bei Benachrichtigung"
 
-#: src/prefs.js:207
+#: src/prefs.ui:148 src/prefs.ui:159
 msgid "Alert even if you set notifications to OFF on user menu (default: OFF)"
 msgstr ""
 "Benachrichtigungen auch dann anzeigen, wenn sie im Nutzermenü ausgeschaltet "
 "sind (Vorgabe: AUS)"
 
-#: src/prefs.js:173
+#: src/prefs.ui:30
 msgid "Alert font color"
 msgstr "Schriftfarbe bei Benachrichtigung"
 
-#: src/prefs.js:241
+#: src/prefs.js:80
 msgid "Application"
 msgstr "Anwendung"
 
-#: src/prefs.js:140
+#: src/prefs.ui:214
 msgid "Blacklist"
 msgstr "Schwarze Liste"
 
-#: src/prefs.js:271
+#: src/prefs.js:109
 msgid "Blacklist app"
 msgstr "Anwendung für schwarze Liste"
 
-#: src/prefs.js:184
+#: src/prefs.ui:176
 msgid "Blink rate (in ms)"
 msgstr "Blinkgeschwindigkeit (in ms)"
 
-#: src/prefs.js:281
+#: src/prefs.js:119
 msgid "Choose an application to blacklist:"
 msgstr "Anwendung für schwarze Liste auswählen:"
 
-#: src/prefs.js:123
+#: src/prefs.js:44
 msgid "Filter List"
 msgstr "Filterliste"
 
-#: src/prefs.js:133
+#: src/prefs.ui:206
 msgid "Filter Type"
 msgstr "Filtertyp"
 
-#: src/prefs.js:206
+#: src/prefs.ui:152
 msgid "Force alerting even when notifications are set to OFF"
 msgstr "Auch benachrichtigen, wenn sie allgemein auf AUS gestellt sind"
 
-#: src/prefs.js:202
+#: src/prefs.ui:128
 msgid "Only alert for chat notifications"
 msgstr "Nur bei Chat-Benachrichtigungen aktivieren"
 
-#: src/prefs.js:203
+#: src/prefs.ui:124 src/prefs.ui:135
 msgid ""
 "Only chat notifications (like Empathy ones) will get alerted (default: OFF)"
 msgstr ""
 "Benachrichtigt nur bei Chat-Meldungen (z.B. von Empathy) (Vorgabe: AUS)"
 
-#: src/prefs.js:178
+#: src/prefs.ui:51 src/prefs.ui:63
 msgid "The background color used to paint the message on user's menu"
 msgstr ""
 "Diese Farbe wird verwendet, um den Hintergrund vom Nutzermenü bei "
 "Benachrichtigungen entsprechend einzufärben"
 
-#: src/prefs.js:174
+#: src/prefs.ui:26 src/prefs.ui:38
 msgid "The color used to paint the message on user's menu"
 msgstr ""
 "Diese Farbe wird verwendet, um die Schrift im Nutzermenü bei "
 "Benachrichtigungen entsprechend einzufärben"
 
-#: src/prefs.js:185
+#: src/prefs.ui:172 src/prefs.ui:189
 msgid "The rate that the alert blinks, in ms. 0 means no blink (default: 800)"
 msgstr ""
 "Gibt an, mit welcher Geschwindigkeit der Alarm blinkt (in ms). Wert 0 "
 "bedeutet kein Blinken (Vorgabe: 800)"
 
-#: src/prefs.js:198
+#: src/prefs.ui:104
 msgid "Use alert background color"
 msgstr "Hintergrundfarbe bei Benachrichtigung anwenden"
 
-#: src/prefs.js:194
+#: src/prefs.ui:80
 msgid "Use alert font color"
 msgstr "Schriftfarbe bei Benachrichtigung anwenden"
 
-#: src/prefs.js:199
+#: src/prefs.ui:100 src/prefs.ui:111
 msgid "Use the alert background color for alert blinks (default: OFF)"
 msgstr ""
 "Bei Benachrichtigungen wird der Hintergrund entsprechend dem eingestellten "
 "Wert eingefärbt (Vorgabe: AUS)"
 
-#: src/prefs.js:195
+#: src/prefs.ui:76 src/prefs.ui:87
 msgid "Use the alert font color for alert blinks (default: ON)"
 msgstr ""
 "Bei Benachrichtigungen wird die Schrift entsprechend dem eingestellten Wert "
 "eingefärbt (Vorgabe: AN)"
 
-#: src/prefs.js:141
+#: src/prefs.ui:215
 msgid "Whitelist"
 msgstr "Weiße Liste"

--- a/locale/messages.pot
+++ b/locale/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-12-09 21:12-0300\n"
+"POT-Creation-Date: 2023-03-25 10:34+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,95 +17,95 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/prefs.js:276
+#: src/prefs.js:114
 msgid "Add"
 msgstr ""
 
-#: src/prefs.js:257
+#: src/prefs.js:96
 msgid "Add Rule"
 msgstr ""
 
-#: src/prefs.js:177
+#: src/prefs.ui:55
 msgid "Alert background color"
 msgstr ""
 
-#: src/prefs.js:207
+#: src/prefs.ui:148 src/prefs.ui:159
 msgid "Alert even if you set notifications to OFF on user menu (default: OFF)"
 msgstr ""
 
-#: src/prefs.js:173
+#: src/prefs.ui:30
 msgid "Alert font color"
 msgstr ""
 
-#: src/prefs.js:241
+#: src/prefs.js:80
 msgid "Application"
 msgstr ""
 
-#: src/prefs.js:140
+#: src/prefs.ui:214
 msgid "Blacklist"
 msgstr ""
 
-#: src/prefs.js:271
+#: src/prefs.js:109
 msgid "Blacklist app"
 msgstr ""
 
-#: src/prefs.js:184
+#: src/prefs.ui:176
 msgid "Blink rate (in ms)"
 msgstr ""
 
-#: src/prefs.js:281
+#: src/prefs.js:119
 msgid "Choose an application to blacklist:"
 msgstr ""
 
-#: src/prefs.js:123
+#: src/prefs.js:44
 msgid "Filter List"
 msgstr ""
 
-#: src/prefs.js:133
+#: src/prefs.ui:206
 msgid "Filter Type"
 msgstr ""
 
-#: src/prefs.js:206
+#: src/prefs.ui:152
 msgid "Force alerting even when notifications are set to OFF"
 msgstr ""
 
-#: src/prefs.js:202
+#: src/prefs.ui:128
 msgid "Only alert for chat notifications"
 msgstr ""
 
-#: src/prefs.js:203
+#: src/prefs.ui:124 src/prefs.ui:135
 msgid ""
 "Only chat notifications (like Empathy ones) will get alerted (default: OFF)"
 msgstr ""
 
-#: src/prefs.js:178
+#: src/prefs.ui:51 src/prefs.ui:63
 msgid "The background color used to paint the message on user's menu"
 msgstr ""
 
-#: src/prefs.js:174
+#: src/prefs.ui:26 src/prefs.ui:38
 msgid "The color used to paint the message on user's menu"
 msgstr ""
 
-#: src/prefs.js:185
+#: src/prefs.ui:172 src/prefs.ui:189
 msgid "The rate that the alert blinks, in ms. 0 means no blink (default: 800)"
 msgstr ""
 
-#: src/prefs.js:198
+#: src/prefs.ui:104
 msgid "Use alert background color"
 msgstr ""
 
-#: src/prefs.js:194
+#: src/prefs.ui:80
 msgid "Use alert font color"
 msgstr ""
 
-#: src/prefs.js:199
+#: src/prefs.ui:100 src/prefs.ui:111
 msgid "Use the alert background color for alert blinks (default: OFF)"
 msgstr ""
 
-#: src/prefs.js:195
+#: src/prefs.ui:76 src/prefs.ui:87
 msgid "Use the alert font color for alert blinks (default: ON)"
 msgstr ""
 
-#: src/prefs.js:141
+#: src/prefs.ui:215
 msgid "Whitelist"
 msgstr ""

--- a/locale/nl_NL.po
+++ b/locale/nl_NL.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-12-09 21:12-0300\n"
+"POT-Creation-Date: 2023-03-25 10:34+0100\n"
 "PO-Revision-Date: 2019-08-06 12:16+0200\n"
 "Last-Translator: Heimen Stoffels <vistausss@outlook.com>\n"
 "Language-Team: \n"
@@ -18,106 +18,106 @@ msgstr ""
 "X-Generator: Poedit 2.2.3\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/prefs.js:276
+#: src/prefs.js:114
 msgid "Add"
 msgstr "Toevoegen"
 
-#: src/prefs.js:257
+#: src/prefs.js:96
 msgid "Add Rule"
 msgstr "Regel toevoegen"
 
-#: src/prefs.js:177
+#: src/prefs.ui:55
 #, fuzzy
 msgid "Alert background color"
 msgstr "Meldingskleur"
 
-#: src/prefs.js:207
+#: src/prefs.ui:148 src/prefs.ui:159
 msgid "Alert even if you set notifications to OFF on user menu (default: OFF)"
 msgstr ""
 "Ook knipperen bij nieuwe meldingen als meldingen zijn uitgeschakeld "
 "(standaard: UIT)"
 
-#: src/prefs.js:173
+#: src/prefs.ui:30
 #, fuzzy
 msgid "Alert font color"
 msgstr "Meldingskleur"
 
-#: src/prefs.js:241
+#: src/prefs.js:80
 msgid "Application"
 msgstr "Toepassing"
 
-#: src/prefs.js:140
+#: src/prefs.ui:214
 msgid "Blacklist"
 msgstr "Zwarte lijst"
 
-#: src/prefs.js:271
+#: src/prefs.js:109
 msgid "Blacklist app"
 msgstr "Toev. aan zwarte lijst"
 
-#: src/prefs.js:184
+#: src/prefs.ui:176
 msgid "Blink rate (in ms)"
 msgstr "Knippersnelheid (in ms)"
 
-#: src/prefs.js:281
+#: src/prefs.js:119
 msgid "Choose an application to blacklist:"
 msgstr "Kies een toepassing voor de zwarte lijst:"
 
-#: src/prefs.js:123
+#: src/prefs.js:44
 msgid "Filter List"
 msgstr "Filterlijst"
 
-#: src/prefs.js:133
+#: src/prefs.ui:206
 msgid "Filter Type"
 msgstr "Soort filter"
 
-#: src/prefs.js:206
+#: src/prefs.ui:152
 msgid "Force alerting even when notifications are set to OFF"
 msgstr ""
 "Knipperen bij nieuwe meldingen afdwingen als meldingen zijn uitgeschakeld"
 
-#: src/prefs.js:202
+#: src/prefs.ui:128
 msgid "Only alert for chat notifications"
 msgstr "Alleen knipperen bij chatmeldingen"
 
-#: src/prefs.js:203
+#: src/prefs.ui:124 src/prefs.ui:135
 msgid ""
 "Only chat notifications (like Empathy ones) will get alerted (default: OFF)"
 msgstr ""
 "Alleen knipperen bij chatmeldingen (zoals bijv. die van Empathy - standaard: "
 "UIT)"
 
-#: src/prefs.js:178
+#: src/prefs.ui:51 src/prefs.ui:63
 #, fuzzy
 msgid "The background color used to paint the message on user's menu"
 msgstr "De kleur van het knipperpatroon"
 
-#: src/prefs.js:174
+#: src/prefs.ui:26 src/prefs.ui:38
 msgid "The color used to paint the message on user's menu"
 msgstr "De kleur van het knipperpatroon"
 
-#: src/prefs.js:185
+#: src/prefs.ui:172 src/prefs.ui:189
 msgid "The rate that the alert blinks, in ms. 0 means no blink (default: 800)"
 msgstr ""
 "De snelheid waarmee wordt geknipperd, in ms. 0 = niet knipperen (standaard: "
 "800)"
 
-#: src/prefs.js:198
+#: src/prefs.ui:104
 msgid "Use alert background color"
 msgstr ""
 
-#: src/prefs.js:194
+#: src/prefs.ui:80
 #, fuzzy
 msgid "Use alert font color"
 msgstr "Meldingskleur"
 
-#: src/prefs.js:199
+#: src/prefs.ui:100 src/prefs.ui:111
 msgid "Use the alert background color for alert blinks (default: OFF)"
 msgstr ""
 
-#: src/prefs.js:195
+#: src/prefs.ui:76 src/prefs.ui:87
 msgid "Use the alert font color for alert blinks (default: ON)"
 msgstr ""
 
-#: src/prefs.js:141
+#: src/prefs.ui:215
 msgid "Whitelist"
 msgstr "Witte lijst"

--- a/locale/pt_BR.po
+++ b/locale/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-notifications-alert\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-12-09 21:12-0300\n"
+"POT-Creation-Date: 2023-03-25 10:34+0100\n"
 "PO-Revision-Date: 2013-02-02 17:09-0200\n"
 "Last-Translator: Thiago Bellini <hackedbellini@gmail.com>\n"
 "Language-Team: Brazilian Portuguese\n"
@@ -17,100 +17,100 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/prefs.js:276
+#: src/prefs.js:114
 msgid "Add"
 msgstr "Adicionar"
 
-#: src/prefs.js:257
+#: src/prefs.js:96
 msgid "Add Rule"
 msgstr "Adicionar Regra"
 
-#: src/prefs.js:177
+#: src/prefs.ui:55
 msgid "Alert background color"
 msgstr "Cor de fundo do alerta"
 
-#: src/prefs.js:207
+#: src/prefs.ui:148 src/prefs.ui:159
 msgid "Alert even if you set notifications to OFF on user menu (default: OFF)"
 msgstr ""
 "Alertar mesmo se as suas notificações estão desligadas no menu do usuário "
 "(padrão: Desligado)"
 
-#: src/prefs.js:173
+#: src/prefs.ui:30
 msgid "Alert font color"
 msgstr "Cor da fonte do alerta"
 
-#: src/prefs.js:241
+#: src/prefs.js:80
 msgid "Application"
 msgstr "Aplicativo"
 
-#: src/prefs.js:140
+#: src/prefs.ui:214
 msgid "Blacklist"
 msgstr "Lista negra"
 
-#: src/prefs.js:271
+#: src/prefs.js:109
 msgid "Blacklist app"
 msgstr "Aplicativos na lista negra"
 
-#: src/prefs.js:184
+#: src/prefs.ui:176
 msgid "Blink rate (in ms)"
 msgstr "Taxa de intermitência (em ms)"
 
-#: src/prefs.js:281
+#: src/prefs.js:119
 msgid "Choose an application to blacklist:"
 msgstr "Escolha um aplicativo para adicionar na lista negra:"
 
-#: src/prefs.js:123
+#: src/prefs.js:44
 msgid "Filter List"
 msgstr "Lista do filtro"
 
-#: src/prefs.js:133
+#: src/prefs.ui:206
 msgid "Filter Type"
 msgstr "Tipo do filtro"
 
-#: src/prefs.js:206
+#: src/prefs.ui:152
 msgid "Force alerting even when notifications are set to OFF"
 msgstr "Alerta forçado mesmo quando as notificações estão desligadas"
 
-#: src/prefs.js:202
+#: src/prefs.ui:128
 msgid "Only alert for chat notifications"
 msgstr "Alertar apenas para notificações de bate-papo"
 
-#: src/prefs.js:203
+#: src/prefs.ui:124 src/prefs.ui:135
 msgid ""
 "Only chat notifications (like Empathy ones) will get alerted (default: OFF)"
 msgstr ""
 "Apenas notificações de bate-papo (como as do Empathy) serão alertadas "
 "(padrão: Desligado)"
 
-#: src/prefs.js:178
+#: src/prefs.ui:51 src/prefs.ui:63
 msgid "The background color used to paint the message on user's menu"
 msgstr "A cor utilizada para pintar o fundo da mensagem no menu do usuário"
 
-#: src/prefs.js:174
+#: src/prefs.ui:26 src/prefs.ui:38
 msgid "The color used to paint the message on user's menu"
 msgstr "A cor utilizada para pintar a mensagem no menu do usuário"
 
-#: src/prefs.js:185
+#: src/prefs.ui:172 src/prefs.ui:189
 msgid "The rate that the alert blinks, in ms. 0 means no blink (default: 800)"
 msgstr ""
 "A taxa em que o alerta pisca, em ms. 0 significa não piscar (padrão: 800)"
 
-#: src/prefs.js:198
+#: src/prefs.ui:104
 msgid "Use alert background color"
 msgstr "Usar cor de fundo do alerta"
 
-#: src/prefs.js:194
+#: src/prefs.ui:80
 msgid "Use alert font color"
 msgstr "Cor da fonte do alerta"
 
-#: src/prefs.js:199
+#: src/prefs.ui:100 src/prefs.ui:111
 msgid "Use the alert background color for alert blinks (default: OFF)"
 msgstr "Usar a cor de fundo do alerta ao piscar (padrão: Desligado)"
 
-#: src/prefs.js:195
+#: src/prefs.ui:76 src/prefs.ui:87
 msgid "Use the alert font color for alert blinks (default: ON)"
 msgstr "Usar a cor da fonte do alerta ao piscar (padrão: Ligado)"
 
-#: src/prefs.js:141
+#: src/prefs.ui:215
 msgid "Whitelist"
 msgstr "Lista branca"

--- a/schemas/org.gnome.shell.extensions.notifications-alert.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.notifications-alert.gschema.xml
@@ -13,6 +13,7 @@
     </key>
     <key name="blinkrate" type="i">
       <default>800</default>
+      <range min="0" max="10000"/>
       <summary>Blink rate</summary>
       <description>The rate that the alert blinks, in ms. 0 means no blink</description>
     </key>

--- a/src/extension.js
+++ b/src/extension.js
@@ -207,16 +207,17 @@ function _MessageStyleHandler() {
   }
 
   this._removeMessageStyle = function() {
-    if (!this._hasStyleAdded) {
-      return;
-    }
-
-    this._hasStyleAdded = false;
     if (this._loopTimeoutId != null) {
       // Stop the looping
       Mainloop.source_remove(this._loopTimeoutId);
       this._loopTimeoutId = null;
     }
+    
+    if (!this._hasStyleAdded) {
+      return;
+    }
+
+    this._hasStyleAdded = false;
 
     let dateMenu = Main.panel.statusArea.dateMenu;
     let actor = dateMenu instanceof Clutter.Actor ? dateMenu : dateMenu.actor;

--- a/src/extension.js
+++ b/src/extension.js
@@ -23,7 +23,6 @@
  */
 
 const { Clutter, St } = imports.gi;
-const Lang = imports.lang;
 const Mainloop = imports.mainloop;
 const Main = imports.ui.main;
 const MessageTray = imports.ui.messageTray;
@@ -60,20 +59,20 @@ function _MessageStyleHandler() {
     this._hasStyleAdded = false;
 
     this._presence = new GnomeSession.Presence(
-      Lang.bind(this, function(proxy, error) {
+      (proxy, error) => {
         if (error) {
           logError(error, 'Error while reading gnome-session presence');
           return;
         }
-    }));
+    });
   }
 
   this.enable = function() {
     this._statusChangedId = this._presence.connectSignal(
-      'StatusChanged', Lang.bind(this, function(proxy, senderName, [status]) {
+      'StatusChanged', (proxy, senderName, [status]) => {
         this._presence.status = status;
         this._onNotificationsSwitchToggled();
-    }));
+    });
 
     // Connect settings change events, so we can update message style
     // as soon as the user makes the change
@@ -147,7 +146,7 @@ function _MessageStyleHandler() {
 
   this._connectSetting = function(setting) {
     this._signals[setting] = settings.connect(
-      "changed::" + setting, Lang.bind(this, this._onSettingsChanged));
+      "changed::" + setting, this._onSettingsChanged.bind(this));
   }
 
   this._hasNotifications = function(source) {
@@ -201,7 +200,7 @@ function _MessageStyleHandler() {
 
     if (loopDelay > 0) {
       this._loopTimeoutId = Mainloop.timeout_add(
-          loopDelay, Lang.bind(this, this._toggleStyle))
+          loopDelay, this._toggleStyle.bind(this))
     } else {
       this._toggleStyle();
     }

--- a/src/extension.js
+++ b/src/extension.js
@@ -259,13 +259,14 @@ function _destroy() {
 
 function init() {
   ExtensionUtils.initTranslations();
+}
+
+function enable() {
   settings = ExtensionUtils.getSettings();
 
   messageStyleHandler = new _MessageStyleHandler();
   messageStyleHandler.init();
-}
 
-function enable() {
   if (MessageTray.Source.prototype.countUpdated == _countUpdated) {
     return;
   }
@@ -283,4 +284,9 @@ function disable() {
   MessageTray.Source.prototype.destroy = originalDestroy;
 
   messageStyleHandler.disable();
+
+  settings = null;
+  messageStyleHandler = null;
+  originalCountUpdated = null;
+  originalDestroy = null;
 }

--- a/src/extension.js
+++ b/src/extension.js
@@ -258,8 +258,8 @@ function _destroy() {
 */
 
 function init() {
-  Lib.initTranslations(Me);
-  settings = Lib.getSettings(Me);
+  ExtensionUtils.initTranslations();
+  settings = ExtensionUtils.getSettings();
 
   messageStyleHandler = new _MessageStyleHandler();
   messageStyleHandler.init();

--- a/src/lib.js
+++ b/src/lib.js
@@ -27,55 +27,6 @@ const Gio = imports.gi.Gio;
 const Config = imports.misc.config;
 
 /*
-   Extension utils
- */
-
-function initTranslations(extension) {
-  // This is the same as UUID from metadata.json
-  let domain = 'gnome-shell-notifications-alert';
-
-  // check if this extension was built with "make zip-file", and thus
-  // has the locale files in a subfolder
-  // otherwise assume that extension has been installed in the
-  // same prefix as gnome-shell
-  let localeDir = extension.dir.get_child('locale');
-  if (localeDir.query_exists(null)) {
-    Gettext.bindtextdomain(domain, localeDir.get_path());
-  } else {
-    Gettext.bindtextdomain(domain, Config.LOCALEDIR);
-  }
-}
-
-function getSettings(extension) {
-  let schema = 'org.gnome.shell.extensions.notifications-alert';
-
-  const GioSSS = Gio.SettingsSchemaSource;
-
-  // check if this extension was built with "make zip-file", and thus
-  // has the schema files in a subfolder
-  // otherwise assume that extension has been installed in the
-  // same prefix as gnome-shell (and therefore schemas are available
-  // in the standard folders)
-  let schemaDir = extension.dir.get_child('schemas');
-  let schemaSource;
-  if (schemaDir.query_exists(null)) {
-    schemaSource = GioSSS.new_from_directory(schemaDir.get_path(),
-                                             GioSSS.get_default(),
-                                             false);
-  } else {
-    schemaSource = GioSSS.get_default();
-  }
-
-  let schemaObj = schemaSource.lookup(schema, true);
-  if (!schemaObj) {
-    throw new Error('Schema ' + schema + ' could not be found for extension ' +
-                    extension.metadata.uuid + '. Please check your installation.');
-  }
-
-  return new Gio.Settings({settings_schema: schemaObj});
-}
-
-/*
    Color utils
  */
 

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -6,6 +6,8 @@
     "43",
     "44"
   ],
+  "gettext-domain": "gnome-shell-notifications-alert",
+  "settings-schema": "org.gnome.shell.extensions.notifications-alert",
   "uuid": "notifications-alert-on-user-menu@hackedbellini.gmail.com",
   "name": "Notifications Alert",
   "original-authors": [

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -40,84 +40,6 @@ const Columns = {
   ICON: 2,
 };
 
-let settings;
-let boolSettings;
-let intSettings;
-let colorSettings;
-
-function _createBoolSetting(setting) {
-  let hbox = new Gtk.Box({orientation: Gtk.Orientation.HORIZONTAL});
-
-  let settingLabel = new Gtk.Label({label: boolSettings[setting].label,
-                                    xalign: 0, hexpand: true});
-
-  let settingSwitch = new Gtk.Switch({active: settings.get_boolean(setting)});
-  settingSwitch.connect('notify::active', function(button) {
-    settings.set_boolean(setting, button.active);
-  });
-
-  if (boolSettings[setting].help) {
-    settingLabel.set_tooltip_text(boolSettings[setting].help);
-    settingSwitch.set_tooltip_text(boolSettings[setting].help);
-  }
-
-  hbox.prepend(settingLabel);
-  hbox.append(settingSwitch);
-
-  return hbox;
-}
-
-function _createIntSetting(setting) {
-  let hbox = new Gtk.Box({orientation: Gtk.Orientation.HORIZONTAL});
-
-  let settingLabel = new Gtk.Label({label: intSettings[setting].label,
-                                    xalign: 0, hexpand: true});
-
-  let spinButton = Gtk.SpinButton.new_with_range(
-    intSettings[setting].min,
-    intSettings[setting].max,
-    intSettings[setting].step)
-  spinButton.set_value(settings.get_int(setting));
-  spinButton.connect('notify::value', function(spin) {
-    settings.set_int(setting, spin.get_value_as_int());
-  });
-
-  if (intSettings[setting].help) {
-    settingLabel.set_tooltip_text(intSettings[setting].help);
-    spinButton.set_tooltip_text(intSettings[setting].help);
-  }
-
-  hbox.prepend(settingLabel);
-  hbox.append(spinButton);
-
-  return hbox;
-}
-
-function _createColorSetting(setting) {
-  let hbox = new Gtk.Box({orientation: Gtk.Orientation.HORIZONTAL});
-
-  let settingLabel = new Gtk.Label({label: colorSettings[setting].label,
-                                    xalign: 0, hexpand: true});
-
-  let color = Lib.getRGBAColor(settings.get_string(setting));
-  let colorButton = new Gtk.ColorButton();
-  colorButton.set_rgba(color);
-  colorButton.connect('notify::rgba', function(button) {
-    let rgba = button.get_rgba().to_string();
-    settings.set_string(setting, rgba);
-  });
-
-  if (colorSettings[setting].help) {
-    settingLabel.set_tooltip_text(colorSettings[setting].help);
-    colorButton.set_tooltip_text(colorSettings[setting].help);
-  }
-
-  hbox.prepend(settingLabel);
-  hbox.append(colorButton);
-
-  return hbox;
-}
-
 function _createFilterListSetting() {
   let settingLabel = new Gtk.Label({label: _("Filter List"), xalign: 0});
   let widget = new Widget();
@@ -126,88 +48,6 @@ function _createFilterListSetting() {
   blbox.attach(widget,0,1,1,1);
   return blbox;
 }
-
-function _createFilterTypeSetting() {
-  let hbox = new Gtk.Box({orientation: Gtk.Orientation.HORIZONTAL});
-  let settingLabel = new Gtk.Label({label: _("Filter Type"), xalign: 0, hexpand: true});
-
-  let listStore = new Gtk.ListStore();
-  listStore.set_column_types ([
-    GObject.TYPE_STRING,
-    GObject.TYPE_STRING]);
-
-  listStore.insert_with_values (-1,  [0, 1], [0, _("Blacklist")]); //valuesv
-  listStore.insert_with_values (-1,  [0, 1], [1, _("Whitelist")]); //valuesv
-
-  let filterComboBox = new Gtk.ComboBox({ model: listStore });
-  filterComboBox.set_active (settings.get_int(SETTING_FILTER_TYPE));
-  filterComboBox.set_id_column(0);
-
-  let rendererText = new Gtk.CellRendererText();
-  filterComboBox.pack_start (rendererText, false);
-  filterComboBox.add_attribute (rendererText, "text", 1);
-
-  filterComboBox.connect('changed', function(entry) {
-    let id = filterComboBox.get_active_id();
-    if (id == null)
-        return;
-    settings.set_int(SETTING_FILTER_TYPE, id);
-  });
-
-  hbox.prepend(settingLabel);
-  hbox.append(filterComboBox);
-  return hbox;
-}
-
-/*
-   Shell-extensions handlers
-*/
-
-function init() {
-  ExtensionUtils.initTranslations();
-  settings = ExtensionUtils.getSettings();
-
-  colorSettings = {
-    color: {
-      label: _("Alert font color"),
-      help: _("The color used to paint the message on user's menu")
-    },
-    backgroundcolor: {
-      label: _("Alert background color"),
-      help: _("The background color used to paint the message on user's menu")
-    },
-  };
-
-  intSettings = {
-    blinkrate: {
-      label: _("Blink rate (in ms)"),
-      help: _("The rate that the alert blinks, in ms. 0 means no blink (default: 800)"),
-      min: 0,
-      max: 10000,
-      step: 1
-    },
-  };
-
-  boolSettings = {
-    usecolor: {
-      label: _("Use alert font color"),
-      help: _("Use the alert font color for alert blinks (default: ON)")
-    },
-    usebackgroundcolor: {
-      label: _("Use alert background color"),
-      help: _("Use the alert background color for alert blinks (default: OFF)")
-    },
-    chatonly: {
-      label: _("Only alert for chat notifications"),
-      help: _("Only chat notifications (like Empathy ones) will get alerted (default: OFF)")
-    },
-    force: {
-      label: _("Force alerting even when notifications are set to OFF"),
-      help: _("Alert even if you set notifications to OFF on user menu (default: OFF)")
-    },
-  };
-}
-
 
 /*
    Blacklist widget
@@ -375,37 +215,84 @@ const Widget = new GObject.Class({
   }
 });
 
+/**
+ * PrefsWidget
+ */
+const PrefsWidget = GObject.registerClass({
+  GTypeName: 'PrefsWidget',
+  Template: Me.dir.get_child('prefs.ui').get_uri(),
+  InternalChildren: [
+    'font_color',
+    'background_color',
+    'use_font_color',
+    'use_background_color',
+    'chat_only',
+    'force_alerting',
+    'blink_rate',
+    'filter_type',
+    'filter_box',
+  ],
+}, class PrefsWidget extends Gtk.Box {
+
+  _init(params = {}) {
+    super._init(params);
+    this._settings = ExtensionUtils.getSettings();
+
+    // color settings
+    this._connectColorSettings('color', 'font_color', 'notify::rgba');
+    this._connectColorSettings('backgroundcolor', 'background_color', 'notify::rgba');
+
+    // boolean settings
+    this._bindSettings('usecolor', 'use_font_color', 'active');
+    this._bindSettings('usebackgroundcolor', 'use_background_color', 'active');
+    this._bindSettings('chatonly', 'chat_only', 'active');
+    this._bindSettings('force', 'force_alerting', 'active');
+
+    // int setting
+    this._bindSettings('blinkrate', 'blink_rate', 'value');
+
+    // filter type setting
+    this._widget('filter_type').set_active(this._settings.get_int('filter'));
+    this._widget('filter_type').connect('changed', comboBox => {
+      this._settings.set_int('filter', comboBox.get_active());
+    });
+
+    // filter list
+    this._widget('filter_box').append(_createFilterListSetting());
+  }
+
+  _widget(id) {
+    const name = '_' + id;
+    if (!this[name]) {
+        throw `Unknown widget with ID "${id}"!`;
+    }
+    return this[name];
+  }
+
+  _connectColorSettings(settingsKey, widgetId, signal) {
+    this._widget(widgetId).set_rgba(Lib.getRGBAColor(this._settings.get_string(settingsKey)));
+    this._widget(widgetId).connect(signal, button => {
+      let rgba = button.get_rgba().to_string();
+      this._settings.set_string(settingsKey, rgba);
+    });
+  }
+
+  _bindSettings(settingsKey, widgetId, widgetProperty, flag = Gio.SettingsBindFlags.DEFAULT) {
+      const widget = this._widget(widgetId);
+      this._settings.bind(settingsKey, widget, widgetProperty, flag);
+      this._settings.bind_writable(settingsKey, widget, 'sensitive', false);
+  }
+});
+
+
+/**
+ * Shell-extensions handlers
+ */
+
+function init() {
+  ExtensionUtils.initTranslations('gnome-shell-notifications-alert');
+}
+
 function buildPrefsWidget() {
-  let frame = new Gtk.Box({orientation: Gtk.Orientation.VERTICAL});
-  let vbox = new Gtk.Box({orientation: Gtk.Orientation.VERTICAL, spacing: 5,
-                          margin_top: 10, margin_bottom: 20, margin_start: 20, margin_end: 20});
-  let setting;
-
-  // Add all color settings
-  for (setting in colorSettings) {
-    let hbox = _createColorSetting(setting);
-    vbox.append(hbox);
-  }
-  // Add all bool settings
-  for (setting in boolSettings) {
-    let hbox = _createBoolSetting(setting);
-    vbox.append(hbox);
-  }
-  // Add all int settings
-  for (setting in intSettings) {
-    let hbox = _createIntSetting(setting);
-    vbox.append(hbox);
-  }
-
-  // Add filter type setting
-  let filterType = _createFilterTypeSetting();
-  vbox.append(filterType);
-
-  // Add filter list
-  let blbox = _createFilterListSetting();
-  vbox.append(blbox);
-
-  frame.append(vbox);
-
-  return frame;
+  return new PrefsWidget();
 }

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -164,8 +164,8 @@ function _createFilterTypeSetting() {
 */
 
 function init() {
-  Lib.initTranslations(Me);
-  settings = Lib.getSettings(Me);
+  ExtensionUtils.initTranslations();
+  settings = ExtensionUtils.getSettings();
 
   colorSettings = {
     color: {
@@ -221,8 +221,8 @@ const Widget = new GObject.Class({
     this.parent(params);
     this.set_orientation(Gtk.Orientation.VERTICAL);
 
-    Lib.initTranslations(Me);
-    this._settings = Lib.getSettings(Me);
+    ExtensionUtils.initTranslations();
+    this._settings = ExtensionUtils.getSettings();
 
     this._store = new Gtk.ListStore();
     this._store.set_column_types([Gio.AppInfo, GObject.TYPE_STRING, Gio.Icon]);

--- a/src/prefs.ui
+++ b/src/prefs.ui
@@ -1,0 +1,228 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface domain="gnome-shell-notifications-alert">
+  <template class="PrefsWidget" parent="GtkBox">
+    <property name="visible">True</property>
+    <property name="can-focus">True</property>
+    <property name="orientation">vertical</property>
+    <property name="spacing">15</property>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can-focus">True</property>
+        <property name="margin-start">20</property>
+        <property name="margin-end">20</property>
+        <property name="margin-top">10</property>
+        <property name="margin-bottom">20</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">5</property>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes">The color used to paint the message on user's menu</property>
+                <property name="halign">start</property>
+                <property name="margin-end">5</property>
+                <property name="hexpand">True</property>
+                <property name="label" translatable="yes">Alert font color</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkColorButton" id="font_color">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="tooltip-text" translatable="yes">The color used to paint the message on user's menu</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes">The background color used to paint the message on user's menu</property>
+                <property name="halign">start</property>
+                <property name="margin-end">5</property>
+                <property name="hexpand">True</property>
+                <property name="label" translatable="yes">Alert background color</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkColorButton" id="background_color">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="tooltip-text" translatable="yes">The background color used to paint the message on user's menu</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes">Use the alert font color for alert blinks (default: ON)</property>
+                <property name="halign">start</property>
+                <property name="margin-end">5</property>
+                <property name="hexpand">True</property>
+                <property name="label" translatable="yes">Use alert font color</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkSwitch" id="use_font_color">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="tooltip-text" translatable="yes">Use the alert font color for alert blinks (default: ON)</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes">Use the alert background color for alert blinks (default: OFF)</property>
+                <property name="halign">start</property>
+                <property name="margin-end">5</property>
+                <property name="hexpand">True</property>
+                <property name="label" translatable="yes">Use alert background color</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkSwitch" id="use_background_color">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="tooltip-text" translatable="yes">Use the alert background color for alert blinks (default: OFF)</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes">Only chat notifications (like Empathy ones) will get alerted (default: OFF)</property>
+                <property name="halign">start</property>
+                <property name="margin-end">5</property>
+                <property name="hexpand">True</property>
+                <property name="label" translatable="yes">Only alert for chat notifications</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkSwitch" id="chat_only">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="tooltip-text" translatable="yes">Only chat notifications (like Empathy ones) will get alerted (default: OFF)</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes">Alert even if you set notifications to OFF on user menu (default: OFF)</property>
+                <property name="halign">start</property>
+                <property name="margin-end">5</property>
+                <property name="hexpand">True</property>
+                <property name="label" translatable="yes">Force alerting even when notifications are set to OFF</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkSwitch" id="force_alerting">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="tooltip-text" translatable="yes">Alert even if you set notifications to OFF on user menu (default: OFF)</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes">The rate that the alert blinks, in ms. 0 means no blink (default: 800)</property>
+                <property name="halign">start</property>
+                <property name="margin-end">5</property>
+                <property name="hexpand">True</property>
+                <property name="label" translatable="yes">Blink rate (in ms)</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkAdjustment" id="adjustment_blink_rate">
+                <property name="lower">0</property>
+                <property name="upper">10000</property>
+                <property name="value">800</property>
+                <property name="step-increment">1</property>
+              </object>
+              <object class="GtkSpinButton" id="blink_rate">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="tooltip-text" translatable="yes">The rate that the alert blinks, in ms. 0 means no blink (default: 800)</property>
+                <property name="adjustment">adjustment_blink_rate</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="halign">start</property>
+                <property name="margin-end">5</property>
+                <property name="hexpand">True</property>
+                <property name="label" translatable="yes">Filter Type</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkComboBoxText" id="filter_type">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <items>
+                  <item translatable="yes">Blacklist</item>
+                  <item translatable="yes">Whitelist</item>
+                </items>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkBox" id="filter_box">
+          </object>
+        </child>
+      </object>
+    </child>
+  </template>
+</interface>


### PR DESCRIPTION
Hey @bellini666, here's what I came up with to address the points in ego review (https://extensions.gnome.org/review/39483). This seems to work so far in gnome 42 and 44. Not sure where to get gnome 40/41 for testing if this is necessary.

Some notes:
- Point 4 seems a bit ambiguous and could also refer to messageStyleHandler.init
- I didn't see a simple/elegant solution for point 6, so I reworked prefs.js, using an .ui file for everything except the blacklist widget

The other points should be fine. What do you think?
I'll test gnome 43 when I'm ready to log out/reboot - which could take a while.