### PR TITLE
Gnome 49 support

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -3,7 +3,8 @@
     "45",
     "46",
     "47",
-    "48"
+    "48",
+    "49"
   ],
   "gettext-domain": "gnome-shell-notifications-alert",
   "settings-schema": "org.gnome.shell.extensions.notifications-alert",


### PR DESCRIPTION
Extension works without any changes.

Fixes https://github.com/bellini666/gnome-shell-notifications-alert/issues/71